### PR TITLE
Fix the base url of API V2.0

### DIFF
--- a/Gameball/Constants/GameballConstants.cs
+++ b/Gameball/Constants/GameballConstants.cs
@@ -9,7 +9,7 @@ namespace Gameball.Constants
     internal static class GameballConstants
     {
         //The base URL for Gameball v2.0 API
-        public const string BaseURL = "https://api.gameball.co/v2.0/";
+        public const string BaseURL = "https://api.gameball.co/api/v2.0/";
 
         //Available endpoints
         public const string Player = "Integrations/Player";


### PR DESCRIPTION
This is a fix to the base url of GameBall API V2.0.

The original url always causes an exception with nessage: ApiKey invalid exception although the keys are valid. e,g; Live, Test and Transaction.

I found this issue while trying to integrate with GameBall in .NET Core 3.1 using the NuGet package.

Further communication, I can be reached through: ahmedshabaan@outlook.com